### PR TITLE
Fix getFileModifications method typo

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -162,7 +162,7 @@ export const ChatImpl = memo(({ initialMessages, storeMessageHistory }: ChatProp
      */
     await workbenchStore.saveAllFiles();
 
-    const fileModifications = workbenchStore.getFileModifcations();
+    const fileModifications = workbenchStore.getFileModifications();
 
     chatStore.setKey('aborted', false);
 

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -202,7 +202,7 @@ export class WorkbenchStore {
     }
   }
 
-  getFileModifcations() {
+  getFileModifications() {
     return this.#filesStore.getFileModifications();
   }
 


### PR DESCRIPTION
## Summary
- rename `getFileModifcations` to `getFileModifications`
- update call sites

## Testing
- `pnpm test` *(fails: unable to download pnpm packages)*
- `pnpm run typecheck` *(fails: unable to download pnpm packages)*

------
https://chatgpt.com/codex/tasks/task_e_68435cf38f1c833395529a07c7a87f34