### PR TITLE
Rename project to Spark.new

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
       value: |
         Thank you for reporting an issue :pray:.
 
-        This issue tracker is for bugs and issues found with [Bolt.new](https://bolt.new).
+        This issue tracker is for bugs and issues found with [Spark.new](https://spark.new).
         If you experience issues related to WebContainer, please file an issue in our [WebContainer repo](https://github.com/stackblitz/webcontainer-core), or file an issue in our [StackBlitz core repo](https://github.com/stackblitz/core) for issues with StackBlitz.
 
         The more information you fill in, the better we can help you.
@@ -20,7 +20,7 @@ body:
   - type: input
     id: link
     attributes:
-      label: Link to the Bolt URL that caused the error
+      label: Link to the Spark URL that caused the error
       description: Please do not delete it after reporting!
     validations:
       required: true
@@ -35,7 +35,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ![Making your project public](https://github.com/stackblitz/bolt.new/blob/main/public/project-visibility.jpg?raw=true)
+        ![Making your project public](https://github.com/stackblitz/spark.new/blob/main/public/project-visibility.jpg?raw=true)
   - type: textarea
     id: steps
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Bolt.new Help Center
-    url: https://support.bolt.new
-    about: Official central repository for tips, tricks, tutorials, known issues, and best practices for bolt.new usage.
+  - name: Spark.new Help Center
+    url: https://support.spark.new
+    about: Official central repository for tips, tricks, tutorials, known issues, and best practices for spark.new usage.
   - name: Billing Issues
-    url: https://support.bolt.new/Billing-13fd971055d680ebb393cb80973710b6
+    url: https://support.spark.new/Billing-13fd971055d680ebb393cb80973710b6
     about: Instructions for billing and subscription related support
   - name: Discord Chat
     url: https://discord.gg/stackblitz

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,39 @@
-[![Bolt Open Source Codebase](./public/social_preview_index.jpg)](https://bolt.new)
+[![Spark Open Source Codebase](./public/social_preview_index.jpg)](https://spark.new)
 
-> Welcome to the **Bolt** open-source codebase! This repo contains a simple example app using the core components from bolt.new to help you get started building **AI-powered software development tools** powered by StackBlitz’s **WebContainer API**.
+> Welcome to the **Spark** open-source codebase! This repo contains a simple example app using the core components from spark.new to help you get started building **AI-powered software development tools** powered by StackBlitz’s **WebContainer API**.
 
-### Why Build with Bolt + WebContainer API
+### Why Build with Spark + WebContainer API
 
-By building with the Bolt + WebContainer API you can create browser-based applications that let users **prompt, run, edit, and deploy** full-stack web apps directly in the browser, without the need for virtual machines. With WebContainer API, you can build apps that give AI direct access and full control over a **Node.js server**, **filesystem**, **package manager** and **dev terminal** inside your users browser tab. This powerful combination allows you to create a new class of development tools that support all major JavaScript libraries and Node packages right out of the box, all without remote environments or local installs.
+By building with the Spark + WebContainer API you can create browser-based applications that let users **prompt, run, edit, and deploy** full-stack web apps directly in the browser, without the need for virtual machines. With WebContainer API, you can build apps that give AI direct access and full control over a **Node.js server**, **filesystem**, **package manager** and **dev terminal** inside your users browser tab. This powerful combination allows you to create a new class of development tools that support all major JavaScript libraries and Node packages right out of the box, all without remote environments or local installs.
 
-### What’s the Difference Between Bolt (This Repo) and [Bolt.new](https://bolt.new)?
+### What’s the Difference Between Spark (This Repo) and [Spark.new](https://spark.new)?
 
-- **Bolt.new**: This is the **commercial product** from StackBlitz—a hosted, browser-based AI development tool that enables users to prompt, run, edit, and deploy full-stack web applications directly in the browser. Built on top of the [Bolt open-source repo](https://github.com/stackblitz/bolt.new) and powered by the StackBlitz **WebContainer API**.
+- **Spark.new**: This is the **commercial product** from StackBlitz—a hosted, browser-based AI development tool that enables users to prompt, run, edit, and deploy full-stack web applications directly in the browser. Built on top of the [Spark open-source repo](https://github.com/stackblitz/spark.new) and powered by the StackBlitz **WebContainer API**.
 
-- **Bolt (This Repo)**: This open-source repository provides the core components used to make **Bolt.new**. This repo contains the UI interface for Bolt as well as the server components, built using [Remix Run](https://remix.run/). By leveraging this repo and StackBlitz’s **WebContainer API**, you can create your own AI-powered development tools and full-stack applications that run entirely in the browser.
+- **Spark (This Repo)**: This open-source repository provides the core components used to make **Spark.new**. This repo contains the UI interface for Spark as well as the server components, built using [Remix Run](https://remix.run/). By leveraging this repo and StackBlitz’s **WebContainer API**, you can create your own AI-powered development tools and full-stack applications that run entirely in the browser.
 
-# Get Started Building with Bolt
+# Get Started Building with Spark
 
-Bolt combines the capabilities of AI with sandboxed development environments to create a collaborative experience where code can be developed by the assistant and the programmer together. Bolt combines [WebContainer API](https://webcontainers.io/api) with [Claude Sonnet 3.5](https://www.anthropic.com/news/claude-3-5-sonnet) using [Remix](https://remix.run/) and the [AI SDK](https://sdk.vercel.ai/).
+Spark combines the capabilities of AI with sandboxed development environments to create a collaborative experience where code can be developed by the assistant and the programmer together. Spark combines [WebContainer API](https://webcontainers.io/api) with [Claude Sonnet 3.5](https://www.anthropic.com/news/claude-3-5-sonnet) using [Remix](https://remix.run/) and the [AI SDK](https://sdk.vercel.ai/).
 
 ### WebContainer API
 
-Bolt uses [WebContainers](https://webcontainers.io/) to run generated code in the browser. WebContainers provide Bolt with a full-stack sandbox environment using [WebContainer API](https://webcontainers.io/api). WebContainers run full-stack applications directly in the browser without the cost and security concerns of cloud hosted AI agents. WebContainers are interactive and editable, and enables Bolt's AI to run code and understand any changes from the user.
+Spark uses [WebContainers](https://webcontainers.io/) to run generated code in the browser. WebContainers provide Spark with a full-stack sandbox environment using [WebContainer API](https://webcontainers.io/api). WebContainers run full-stack applications directly in the browser without the cost and security concerns of cloud hosted AI agents. WebContainers are interactive and editable, and enables Spark's AI to run code and understand any changes from the user.
 
 The [WebContainer API](https://webcontainers.io) is free for personal and open source usage. If you're building an application for commercial usage, you can learn more about our [WebContainer API commercial usage pricing here](https://stackblitz.com/pricing#webcontainer-api).
 
 ### Remix App
 
-Bolt is built with [Remix](https://remix.run/) and
+Spark is built with [Remix](https://remix.run/) and
 deployed using [CloudFlare Pages](https://pages.cloudflare.com/) and
 [CloudFlare Workers](https://workers.cloudflare.com/).
 
 ### AI SDK Integration
 
-Bolt uses the [AI SDK](https://github.com/vercel/ai) to integrate with AI
-models. At this time, Bolt supports using Anthropic's Claude Sonnet 3.5.
-You can get an API key from the [Anthropic API Console](https://console.anthropic.com/) to use with Bolt.
-Take a look at how [Bolt uses the AI SDK](https://github.com/stackblitz/bolt.new/tree/main/app/lib/.server/llm)
+Spark uses the [AI SDK](https://github.com/vercel/ai) to integrate with AI
+models. At this time, Spark supports using Anthropic's Claude Sonnet 3.5.
+You can get an API key from the [Anthropic API Console](https://console.anthropic.com/) to use with Spark.
+Take a look at how [Spark uses the AI SDK](https://github.com/stackblitz/spark.new/tree/main/app/lib/.server/llm)
 
 ## Prerequisites
 
@@ -47,7 +47,7 @@ Before you begin, ensure you have the following installed:
 1. Clone the repository (if you haven't already):
 
 ```bash
-git clone https://github.com/stackblitz/bolt.new.git
+git clone https://github.com/stackblitz/spark.new.git
 ```
 
 2. Install dependencies:

--- a/README.md
+++ b/README.md
@@ -1,54 +1,54 @@
-[![Bolt.new: AI-Powered Full-Stack Web Development in the Browser](./public/social_preview_index.jpg)](https://bolt.new)
+[![Spark.new: AI-Powered Full-Stack Web Development in the Browser](./public/social_preview_index.jpg)](https://spark.new)
 
-# Bolt.new: AI-Powered Full-Stack Web Development in the Browser
+# Spark.new: AI-Powered Full-Stack Web Development in the Browser
 
-Bolt.new is an AI-powered web development agent that allows you to prompt, run, edit, and deploy full-stack applications directly from your browser—no local setup required. If you're here to build your own AI-powered web dev agent using the Bolt open source codebase, [click here to get started!](./CONTRIBUTING.md)
+Spark.new is an AI-powered web development agent that allows you to prompt, run, edit, and deploy full-stack applications directly from your browser—no local setup required. If you're here to build your own AI-powered web dev agent using the Spark open source codebase, [click here to get started!](./CONTRIBUTING.md)
 
-## What Makes Bolt.new Different
+## What Makes Spark.new Different
 
-Claude, v0, etc are incredible- but you can't install packages, run backends or edit code. That’s where Bolt.new stands out:
+Claude, v0, etc are incredible- but you can't install packages, run backends or edit code. That’s where Spark.new stands out:
 
-- **Full-Stack in the Browser**: Bolt.new integrates cutting-edge AI models with an in-browser development environment powered by **StackBlitz’s WebContainers**. This allows you to:
+- **Full-Stack in the Browser**: Spark.new integrates cutting-edge AI models with an in-browser development environment powered by **StackBlitz’s WebContainers**. This allows you to:
   - Install and run npm tools and libraries (like Vite, Next.js, and more)
   - Run Node.js servers
   - Interact with third-party APIs
   - Deploy to production from chat
   - Share your work via a URL
 
-- **AI with Environment Control**: Unlike traditional dev environments where the AI can only assist in code generation, Bolt.new gives AI models **complete control** over the entire  environment including the filesystem, node server, package manager, terminal, and browser console. This empowers AI agents to handle the entire app lifecycle—from creation to deployment.
+- **AI with Environment Control**: Unlike traditional dev environments where the AI can only assist in code generation, Spark.new gives AI models **complete control** over the entire  environment including the filesystem, node server, package manager, terminal, and browser console. This empowers AI agents to handle the entire app lifecycle—from creation to deployment.
 
-Whether you’re an experienced developer, a PM or designer, Bolt.new allows you to build production-grade full-stack applications with ease.
+Whether you’re an experienced developer, a PM or designer, Spark.new allows you to build production-grade full-stack applications with ease.
 
-For developers interested in building their own AI-powered development tools with WebContainers, check out the open-source Bolt codebase in this repo!
+For developers interested in building their own AI-powered development tools with WebContainers, check out the open-source Spark codebase in this repo!
 
 ## Tips and Tricks
 
-Here are some tips to get the most out of Bolt.new:
+Here are some tips to get the most out of Spark.new:
 
-- **Be specific about your stack**: If you want to use specific frameworks or libraries (like Astro, Tailwind, ShadCN, or any other popular JavaScript framework), mention them in your initial prompt to ensure Bolt scaffolds the project accordingly.
+- **Be specific about your stack**: If you want to use specific frameworks or libraries (like Astro, Tailwind, ShadCN, or any other popular JavaScript framework), mention them in your initial prompt to ensure Spark scaffolds the project accordingly.
 
 - **Use the enhance prompt icon**: Before sending your prompt, try clicking the 'enhance' icon to have the AI model help you refine your prompt, then edit the results before submitting.
 
-- **Scaffold the basics first, then add features**: Make sure the basic structure of your application is in place before diving into more advanced functionality. This helps Bolt understand the foundation of your project and ensure everything is wired up right before building out more advanced functionality.
+- **Scaffold the basics first, then add features**: Make sure the basic structure of your application is in place before diving into more advanced functionality. This helps Spark understand the foundation of your project and ensure everything is wired up right before building out more advanced functionality.
 
-- **Batch simple instructions**: Save time by combining simple instructions into one message. For example, you can ask Bolt to change the color scheme, add mobile responsiveness, and restart the dev server, all in one go saving you time and reducing API credit consumption significantly.
+- **Batch simple instructions**: Save time by combining simple instructions into one message. For example, you can ask Spark to change the color scheme, add mobile responsiveness, and restart the dev server, all in one go saving you time and reducing API credit consumption significantly.
 
 ## FAQs
 
 **Where do I sign up for a paid plan?**  
-Bolt.new is free to get started. If you need more AI tokens or want private projects, you can purchase a paid subscription in your [Bolt.new](https://bolt.new) settings, in the lower-left hand corner of the application. 
+Spark.new is free to get started. If you need more AI tokens or want private projects, you can purchase a paid subscription in your [Spark.new](https://spark.new) settings, in the lower-left hand corner of the application. 
 
 **What happens if I hit the free usage limit?**  
 Once your free daily token limit is reached, AI interactions are paused until the next day or until you upgrade your plan.
 
-**Is Bolt in beta?**  
-Yes, Bolt.new is in beta, and we are actively improving it based on feedback.
+**Is Spark in beta?**  
+Yes, Spark.new is in beta, and we are actively improving it based on feedback.
 
-**How can I report Bolt.new issues?**  
-Check out the [Issues section](https://github.com/stackblitz/bolt.new/issues) to report an issue or request a new feature. Please use the search feature to check if someone else has already submitted the same issue/request.
+**How can I report Spark.new issues?**  
+Check out the [Issues section](https://github.com/stackblitz/spark.new/issues) to report an issue or request a new feature. Please use the search feature to check if someone else has already submitted the same issue/request.
 
-**What frameworks/libraries currently work on Bolt?**  
-Bolt.new supports most popular JavaScript frameworks and libraries. If it runs on StackBlitz, it will run on Bolt.new as well.
+**What frameworks/libraries currently work on Spark?**  
+Spark.new supports most popular JavaScript frameworks and libraries. If it runs on StackBlitz, it will run on Spark.new as well.
 
 **How can I add make sure my framework/project works well in bolt?**  
-We are excited to work with the JavaScript ecosystem to improve functionality in Bolt. Reach out to us via [hello@stackblitz.com](mailto:hello@stackblitz.com) to discuss how we can partner!
+We are excited to work with the JavaScript ecosystem to improve functionality in Spark. Reach out to us via [hello@stackblitz.com](mailto:hello@stackblitz.com) to discuss how we can partner!

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -130,7 +130,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                       minHeight: TEXTAREA_MIN_HEIGHT,
                       maxHeight: TEXTAREA_MAX_HEIGHT,
                     }}
-                    placeholder="How can Bolt help you today?"
+                    placeholder="How can Spark help you today?"
                     translate="no"
                   />
                   <ClientOnly>

--- a/app/lib/.server/llm/prompts.ts
+++ b/app/lib/.server/llm/prompts.ts
@@ -3,7 +3,7 @@ import { allowedHTMLElements } from '~/utils/markdown';
 import { stripIndents } from '~/utils/stripIndent';
 
 export const getSystemPrompt = (cwd: string = WORK_DIR) => `
-You are Bolt, an expert AI assistant and exceptional senior software developer with vast knowledge across multiple programming languages, frameworks, and best practices.
+You are Spark, an expert AI assistant and exceptional senior software developer with vast knowledge across multiple programming languages, frameworks, and best practices.
 
 <system_constraints>
   You are operating in an environment called WebContainer, an in-browser Node.js runtime that emulates a Linux system to some degree. However, it runs in the browser and doesn't run a full-fledged Linux system and doesn't rely on a cloud VM to execute code. All code is executed in the browser. It does come with a shell that emulates zsh. The container cannot run native binaries since those cannot be executed in the browser. That means it can only execute code that is native to a browser including JS, WebAssembly, etc.
@@ -69,7 +69,7 @@ You are Bolt, an expert AI assistant and exceptional senior software developer w
       }
 
       -console.log('Hello, World!');
-      +console.log('Hello, Bolt!');
+      +console.log('Hello, Spark!');
       +
       function greet() {
       -  return 'Greetings!';
@@ -85,7 +85,7 @@ You are Bolt, an expert AI assistant and exceptional senior software developer w
 </diff_spec>
 
 <artifact_info>
-  Bolt creates a SINGLE, comprehensive artifact for each project. The artifact contains all necessary steps and components, including:
+  Spark creates a SINGLE, comprehensive artifact for each project. The artifact contains all necessary steps and components, including:
 
   - Shell commands to run including dependencies to install using a package manager (NPM)
   - Files to create and their contents

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -5,7 +5,7 @@ import { Chat } from '~/components/chat/Chat.client';
 import { Header } from '~/components/header/Header';
 
 export const meta: MetaFunction = () => {
-  return [{ title: 'Bolt' }, { name: 'description', content: 'Talk with Bolt, an AI assistant from StackBlitz' }];
+  return [{ title: 'Spark' }, { name: 'description', content: 'Talk with Spark, an AI assistant from StackBlitz' }];
 };
 
 export const loader = () => json({});

--- a/app/utils/diff.ts
+++ b/app/utils/diff.ts
@@ -84,7 +84,7 @@ export function diffFiles(fileName: string, oldFileContent: string, newFileConte
  * <bolt_file_modifications>
  * <diff path="/home/project/index.js">
  * - console.log('Hello, World!');
- * + console.log('Hello, Bolt!');
+ * + console.log('Hello, Spark!');
  * </diff>
  * </bolt_file_modifications>
  * ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bolt",
+  "name": "spark",
   "description": "StackBlitz AI Agent",
   "private": true,
   "license": "MIT",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,7 +43,7 @@ function chrome129IssuePlugin() {
           if (version === 129) {
             res.setHeader('content-type', 'text/html');
             res.end(
-              '<body><h1>Please use Chrome Canary for testing.</h1><p>Chrome 129 has an issue with JavaScript modules & Vite local development, see <a href="https://github.com/stackblitz/bolt.new/issues/86#issuecomment-2395519258">for more information.</a></p><p><b>Note:</b> This only impacts <u>local development</u>. `pnpm run build` and `pnpm run start` will work fine in this browser.</p></body>',
+              '<body><h1>Please use Chrome Canary for testing.</h1><p>Chrome 129 has an issue with JavaScript modules & Vite local development, see <a href="https://github.com/stackblitz/spark.new/issues/86#issuecomment-2395519258">for more information.</a></p><p><b>Note:</b> This only impacts <u>local development</u>. `pnpm run build` and `pnpm run start` will work fine in this browser.</p></body>',
             );
 
             return;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 #:schema node_modules/wrangler/config-schema.json
-name = "bolt"
+name = "spark"
 compatibility_flags = ["nodejs_compat"]
 compatibility_date = "2024-07-01"
 pages_build_output_dir = "./build/client"


### PR DESCRIPTION
## Summary
- rename project references from Bolt.new to Spark.new
- update placeholders and prompts
- rename package and wrangler service names

## Testing
- `pnpm run test` *(fails: Error when performing the request)*

------
https://chatgpt.com/codex/tasks/task_e_684360516fec8333919e515db36ea2ec