### PR TITLE
Fix observer cleanup in useSnapScroll

### DIFF
--- a/app/lib/hooks/useSnapScroll.ts
+++ b/app/lib/hooks/useSnapScroll.ts
@@ -20,6 +20,7 @@ export function useSnapScroll() {
       });
 
       observer.observe(node);
+      observerRef.current = observer;
     } else {
       observerRef.current?.disconnect();
       observerRef.current = undefined;


### PR DESCRIPTION
## Summary
- track resize observer in `useSnapScroll`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684360d182b88333877d75355e07e07e