### PR TITLE
Add parser reset test

### DIFF
--- a/app/lib/runtime/__snapshots__/message-parser.spec.ts.snap
+++ b/app/lib/runtime/__snapshots__/message-parser.spec.ts.snap
@@ -218,3 +218,19 @@ exports[`StreamingMessageParser > valid artifacts without actions > should corre
   "title": "Some title",
 }
 `;
+
+exports[`StreamingMessageParser > should reset state when reset is called > onArtifactOpen 1`] = `
+{
+  "id": "artifact_2",
+  "messageId": "message_1",
+  "title": "Second",
+}
+`;
+
+exports[`StreamingMessageParser > should reset state when reset is called > onArtifactClose 1`] = `
+{
+  "id": "artifact_2",
+  "messageId": "message_1",
+  "title": "Second",
+}
+`;

--- a/app/lib/runtime/message-parser.spec.ts
+++ b/app/lib/runtime/message-parser.spec.ts
@@ -152,6 +152,57 @@ describe('StreamingMessageParser', () => {
       runTest(input, expected);
     });
   });
+
+  it('should reset state when reset is called', () => {
+    const callbacks = {
+      onArtifactOpen: vi.fn<ArtifactCallback>((data) => {
+        expect(data).toMatchSnapshot('onArtifactOpen');
+      }),
+      onArtifactClose: vi.fn<ArtifactCallback>((data) => {
+        expect(data).toMatchSnapshot('onArtifactClose');
+      }),
+      onActionOpen: vi.fn<ActionCallback>((data) => {
+        expect(data).toMatchSnapshot('onActionOpen');
+      }),
+      onActionClose: vi.fn<ActionCallback>((data) => {
+        expect(data).toMatchSnapshot('onActionClose');
+      }),
+    };
+
+    const parser = new StreamingMessageParser({
+      artifactElement: () => '',
+      callbacks,
+    });
+
+    const firstMessage =
+      'Before <boltArtifact title="First" id="artifact_1">foo</boltArtifact> After';
+
+    let message = '';
+    for (const chunk of firstMessage.split('')) {
+      message += chunk;
+      parser.parse('message_1', message);
+    }
+
+    parser.reset();
+    vi.clearAllMocks();
+
+    const secondMessage =
+      'Before <boltArtifact title="Second" id="artifact_2">bar</boltArtifact> After';
+
+    message = '';
+    let result = '';
+
+    for (const chunk of secondMessage.split('')) {
+      message += chunk;
+      result += parser.parse('message_1', message);
+    }
+
+    expect(result).toEqual('Before  After');
+    expect(callbacks.onArtifactOpen).toHaveBeenCalledTimes(1);
+    expect(callbacks.onArtifactClose).toHaveBeenCalledTimes(1);
+    expect(callbacks.onActionOpen).toHaveBeenCalledTimes(0);
+    expect(callbacks.onActionClose).toHaveBeenCalledTimes(0);
+  });
 });
 
 function runTest(input: string | string[], outputOrExpectedResult: string | ExpectedResult) {


### PR DESCRIPTION
## Summary
- extend message-parser tests to verify parser.reset clears state
- update snapshots for the new test

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_684360d9cde083339dbdcd311f14029a